### PR TITLE
Update reboot_router.py

### DIFF
--- a/reboot_router.py
+++ b/reboot_router.py
@@ -50,7 +50,7 @@ def get_client_proof(clientnonce, servernonce, password, salt, iterations):
     client_proof = bytearray()
     i = 0
     while i < client_key.digest_size:
-        client_proof.append(client_key_digest[i] ^ signature_digest[i])
+        client_proof.append(ord(client_key_digest[i]) ^ ord(signature_digest[i]))
         i = i + 1
 
     return hexlify(client_proof)


### PR DESCRIPTION
Fix "TypeError: unsupported operand type(s) for ^: 'str' and 'str'"

PS: Tested on Huawei B525s-23a and works ok. I use it as a sms gateway (api/sms/send-sms) to send notifications from my home automation system.