### PR TITLE
Failsafe in case router is unresponsive/still down

### DIFF
--- a/reboot_router_if_no_connection.py
+++ b/reboot_router_if_no_connection.py
@@ -16,7 +16,10 @@ if __name__ == '__main__':
             print('Checking...',file=sys.stderr)
             if not internet(TEST_HOST, TEST_PORT, TEST_TIMEOUT):
                 print('Internet connection is down. Rebooting router...',file=sys.stderr) 
-                reboot_router()
+                try:
+                    reboot_router()
+                except requests.HTTPError as exception:
+                    print('Router down or unresponsive, trying again later...',file=sys.stderr)
             else:
                 print('Internet connection is up. Will check again in ' + str(CHECK_TIMEOUT) + ' seconds...',file=sys.stderr)
             time.sleep(CHECK_TIMEOUT)               


### PR DESCRIPTION
When restarting the router, for whatever reason, it could take longer than the specified test interval. 
Without this `try-except` clause, we risk a `HTTPError` being raised from the `setup` method in case the router is still unresponsive.